### PR TITLE
Combine "build & deploy" option with "build & deploy & provision"

### DIFF
--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/pom.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/pom.xml
@@ -215,6 +215,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.gwt.gwtmockito</groupId>
       <artifactId>gwtmockito</artifactId>
       <scope>test</scope>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/DeploymentScreenPopupViewImpl.ui.xml
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/DeploymentScreenPopupViewImpl.ui.xml
@@ -21,50 +21,48 @@
              xmlns:bootstrap='urn:import:org.gwtbootstrap3.client.ui'
              xmlns:select="urn:import:org.gwtbootstrap3.extras.select.client.ui">
 
-  <ui:with field="i18n"
-           type="org.kie.workbench.common.screens.projecteditor.client.resources.i18n.ProjectEditorConstants"/>
-  <ui:with field="resources"
-           type="org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources"/>
+    <ui:with field="i18n"
+             type="org.kie.workbench.common.screens.projecteditor.client.resources.i18n.ProjectEditorConstants"/>
 
-  <ui:style>
-    .mandatory-field {
-      color: red;
-    }
-  </ui:style>
+    <gwt:HTMLPanel>
+        <bootstrap:Container fluid="true">
+            <bootstrap:Row>
+                <bootstrap:Column size="12">
+                    <bootstrap:Form type="HORIZONTAL">
+                        <bootstrap:FieldSet>
 
-  <gwt:HTMLPanel>
-    <bootstrap:Well>
-      <bootstrap:FieldSet>
+                            <bootstrap:FormGroup ui:field="containerIdTextGroup">
+                                <bootstrap:FormLabel ui:field="containerIdLabel" for="containerIdText" showRequiredIndicator="true" addStyleNames="col-md-4">
+                                    <ui:text from="{i18n.ContainerId}"/>
+                                </bootstrap:FormLabel>
+                                <bootstrap:Column size="MD_8">
+                                    <bootstrap:TextBox bootstrap:id="containerIdText" ui:field="containerIdText" placeholder="{i18n.ContainerId}"/>
+                                    <bootstrap:HelpBlock ui:field="containerIdTextHelpInline"/>
+                                </bootstrap:Column>
+                            </bootstrap:FormGroup>
 
-        <bootstrap:FormGroup ui:field="containerIdTextGroup">
-          <bootstrap:FormLabel ui:field="containerIdLabel" for="containerIdText" showRequiredIndicator="true" addStyleNames="col-md-4">
-            <ui:text from="{i18n.ContainerId}"/>
-          </bootstrap:FormLabel>
-          <bootstrap:Column size="MD_8">
-            <bootstrap:TextBox bootstrap:id="containerIdText" ui:field="containerIdText" placeholder="{i18n.ContainerId}"/>
-            <bootstrap:HelpBlock ui:field="containerIdTextHelpInline"/>
-          </bootstrap:Column>
-        </bootstrap:FormGroup>
+                            <bootstrap:FormGroup ui:field="serverTemplateGroup" visible="false">
+                                <bootstrap:FormLabel ui:field="serverTemplateLabel" for="serverTemplateDropdown" showRequiredIndicator="true" addStyleNames="col-md-4">
+                                    <ui:text from="{i18n.ServerTemplate}"/>
+                                </bootstrap:FormLabel>
+                                <bootstrap:Column size="MD_8">
+                                    <select:Select bootstrap:id="serverTemplateDropdown" ui:field="serverTemplateDropdown"/>
+                                    <bootstrap:HelpBlock ui:field="serverTemplateHelpInline"/>
+                                </bootstrap:Column>
+                            </bootstrap:FormGroup>
 
-        <bootstrap:FormGroup ui:field="serverTemplateGroup">
-          <bootstrap:FormLabel ui:field="serverTemplateLabel" for="serverTemplateDropdown" showRequiredIndicator="true" addStyleNames="col-md-4">
-            <ui:text from="{i18n.ServerTemplate}"/>
-          </bootstrap:FormLabel>
-          <bootstrap:Column size="MD_8">
-            <select:Select bootstrap:id="serverTemplateDropdown" ui:field="serverTemplateDropdown"/>
-            <bootstrap:HelpBlock ui:field="serverTemplateHelpInline"/>
-          </bootstrap:Column>
-        </bootstrap:FormGroup>
-
-        <bootstrap:FormGroup ui:field="startContainerRow">
-          <bootstrap:FormLabel ui:field="startContainerCheckLabel" for="startContainerCheck" addStyleNames="col-md-4">
-            <ui:text from="{i18n.StartContainer}"/>
-          </bootstrap:FormLabel>
-          <bootstrap:Column size="MD_8">
-            <bootstrap:CheckBox ui:field="startContainerCheck"/>
-          </bootstrap:Column>
-        </bootstrap:FormGroup>
-      </bootstrap:FieldSet>
-    </bootstrap:Well>
-  </gwt:HTMLPanel>
+                            <bootstrap:FormGroup ui:field="startContainerRow">
+                                <bootstrap:FormLabel ui:field="startContainerCheckLabel" for="startContainerCheck" addStyleNames="col-md-4">
+                                    <ui:text from="{i18n.StartContainer}"/>
+                                </bootstrap:FormLabel>
+                                <bootstrap:Column size="MD_8">
+                                    <bootstrap:CheckBox ui:field="startContainerCheck"/>
+                                </bootstrap:Column>
+                            </bootstrap:FormGroup>
+                        </bootstrap:FieldSet>
+                    </bootstrap:Form>
+                </bootstrap:Column>
+            </bootstrap:Row>
+        </bootstrap:Container>
+    </gwt:HTMLPanel>
 </ui:UiBinder>

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenView.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenView.java
@@ -16,8 +16,6 @@
 
 package org.kie.workbench.common.screens.projecteditor.client.editor;
 
-import java.util.Collection;
-
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.gwt.user.client.ui.Widget;
 import org.guvnor.common.services.project.model.POM;
@@ -25,7 +23,6 @@ import org.guvnor.common.services.project.model.ProjectImports;
 import org.guvnor.common.services.project.model.ProjectRepositories;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.gwtbootstrap3.client.ui.ButtonGroup;
-import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.workbench.common.services.shared.kmodule.KModuleModel;
 import org.kie.workbench.common.services.shared.whitelist.WhiteList;
 import org.uberfire.ext.widgets.common.client.common.HasBusyIndicator;
@@ -66,11 +63,6 @@ public interface ProjectScreenView
         void triggerBuild();
 
         void triggerBuildAndDeploy();
-
-        void triggerBuildAndDeployAndProvision( String containerId,
-                                    String serverTemplate );
-
-        void loadServerTemplates();
 
     }
 
@@ -173,11 +165,4 @@ public interface ProjectScreenView
                                  Command noCommand,
                                  Command cancelCommand );
 
-    void setServerTemplates(Collection<ServerTemplate> serverTemplates);
-
-    String getContainerId();
-
-    String getServerTemplate();
-
-    boolean getStartContainer();
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenViewImpl.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenViewImpl.java
@@ -16,7 +16,6 @@
 
 package org.kie.workbench.common.screens.projecteditor.client.editor;
 
-import java.util.Collection;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -26,7 +25,6 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
-import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DeckPanel;
@@ -50,7 +48,6 @@ import org.gwtbootstrap3.client.ui.constants.ButtonSize;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
 import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.Toggle;
-import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.workbench.common.screens.projecteditor.client.forms.KModuleEditorPanel;
 import org.kie.workbench.common.screens.projecteditor.client.forms.dependencies.DependencyGrid;
 import org.kie.workbench.common.screens.projecteditor.client.forms.repositories.RepositoriesWidgetPresenter;
@@ -90,7 +87,6 @@ public class ProjectScreenViewImpl
     private MetadataWidget importsPageMetadata;
     private RepositoriesWidgetPresenter repositoriesWidgetPresenter;
     private DependencyGrid dependencyGrid;
-    private Boolean supportDeployToRuntime = Boolean.TRUE;
     private Boolean isGAVCheckDisabled = Boolean.FALSE;
     private Widget projectScreen;
     private SimplePanel layout;
@@ -132,9 +128,6 @@ public class ProjectScreenViewImpl
 
     @Inject
     BusyIndicatorView busyIndicatorView;
-
-    @Inject
-    DeploymentScreenPopupViewImpl deploymentScreenPopupView;
 
     public ProjectScreenViewImpl() {
     }
@@ -415,25 +408,6 @@ public class ProjectScreenViewImpl
                     } );
                 }} );
 
-                add( new AnchorListItem( ProjectEditorResources.CONSTANTS.BuildAndDeployAndProvision() ) {{
-                    addClickHandler( new ClickHandler() {
-                        @Override
-                        public void onClick( ClickEvent event ) {
-                            presenter.loadServerTemplates();
-                            deploymentScreenPopupView.configure( new Command() {
-                                @Override
-                                public void execute() {
-                                    String containerId = deploymentScreenPopupView.getContainerId();
-                                    String serverTemplate = deploymentScreenPopupView.getServerTemplate();
-
-                                    presenter.triggerBuildAndDeployAndProvision( containerId, serverTemplate );
-                                    deploymentScreenPopupView.hide();
-                                }
-                            } );
-                        }
-                    } );
-                }} );
-
             }} );
         }};
     }
@@ -595,29 +569,4 @@ public class ProjectScreenViewImpl
         popup.show();
     }
 
-    @Override
-    public void setServerTemplates(Collection<ServerTemplate> serverTemplates) {
-        if (serverTemplates != null && !serverTemplates.isEmpty()) {
-            for (ServerTemplate serverTemplate : serverTemplates) {
-                deploymentScreenPopupView.addServerTemplate(serverTemplate);
-            }
-            // show it only when there are active servers
-            deploymentScreenPopupView.show();
-        }
-    }
-
-    @Override
-    public String getContainerId() {
-        return deploymentScreenPopupView.getContainerId();
-    }
-
-    @Override
-    public String getServerTemplate() {
-        return deploymentScreenPopupView.getServerTemplate();
-    }
-
-    @Override
-    public boolean getStartContainer() {
-        return deploymentScreenPopupView.getStartContainer();
-    }
 }

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/java/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.java
@@ -87,8 +87,6 @@ public interface ProjectEditorConstants
 
     String BuildAndDeploy();
 
-    String BuildAndDeployAndProvision();
-
     String SaveBeforeBuildAndDeploy();
 
     String Building();
@@ -280,6 +278,8 @@ public interface ProjectEditorConstants
     String ServerTemplate();
 
     String StartContainer();
+
+    String ContainerIdAlreadyInUse();
 
     String FieldMandatory0( final String fieldName );
 

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/resources/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.properties
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/main/resources/org/kie/workbench/common/screens/projecteditor/client/resources/i18n/ProjectEditorConstants.properties
@@ -163,5 +163,5 @@ DependencyIsMissingAGroupId=Dependency is missing a group ID
 Dependency=Dependency
 DeploySuccessful=Deployment to server template successful
 StartContainer=Start container?
-BuildAndDeployAndProvision=Build & Deploy & Provision
 NoServersAvailableForProvisioning=Unable to provision due to no active servers available
+ContainerIdAlreadyInUse=Container name is already in use, please choose a different name.

--- a/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterTest.java
+++ b/kie-wb-common-screens/kie-wb-common-project-editor/kie-wb-common-project-editor-client/src/test/java/org/kie/workbench/common/screens/projecteditor/client/editor/ProjectScreenPresenterTest.java
@@ -17,6 +17,7 @@
 package org.kie.workbench.common.screens.projecteditor.client.editor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.enterprise.event.Event;
 
+import com.google.common.collect.Sets;
 import com.google.gwtmockito.GwtMock;
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.guvnor.common.services.project.builder.model.BuildMessage;
@@ -50,6 +52,8 @@ import org.jboss.errai.common.client.api.RemoteCallback;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.workbench.common.screens.projecteditor.client.editor.extension.BuildOptionExtension;
 import org.kie.workbench.common.screens.projecteditor.client.resources.ProjectEditorResources;
 import org.kie.workbench.common.screens.projecteditor.client.validation.ProjectNameValidator;
@@ -62,6 +66,7 @@ import org.kie.workbench.common.services.shared.validation.ValidationService;
 import org.kie.workbench.common.widgets.client.resources.i18n.CommonConstants;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -80,10 +85,7 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.workbench.events.NotificationEvent;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.eq;
 
 @RunWith(GwtMockitoTestRunner.class)
 public class ProjectScreenPresenterTest {
@@ -107,6 +109,9 @@ public class ProjectScreenPresenterTest {
     @GwtMock
     @SuppressWarnings("unused")
     private com.google.gwt.user.client.ui.Widget dependenciesPart;
+
+    @Mock
+    private DeploymentScreenPopupViewImpl deploymentScreenPopupView;
 
     @Spy
     private MockLockManagerInstances lockManagerInstanceProvider = new MockLockManagerInstances();
@@ -246,6 +251,80 @@ public class ProjectScreenPresenterTest {
     }
 
     @Test
+    public void testBuildAndDeployCommandSingleServerTemplate() {
+        final ServerTemplate serverTemplate = new ServerTemplate("id", "name");
+        when(specManagementServiceMock.listServerTemplates()).thenReturn(Collections.singletonList(serverTemplate));
+
+        presenter.triggerBuildAndDeploy();
+
+        ArgumentCaptor<ContainerSpec> containerSpecArgumentCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify( specManagementServiceMock ).saveContainerSpec( eq(serverTemplate.getId()), containerSpecArgumentCaptor.capture() );
+        final ContainerSpec containerSpec = containerSpecArgumentCaptor.getValue();
+        assertEquals(project.getPom().getGav().getArtifactId(), containerSpec.getContainerName());
+
+        verify( notificationEvent ).fire( argThat( new ArgumentMatcher<NotificationEvent>() {
+            @Override
+            public boolean matches( final Object argument ) {
+                final NotificationEvent event = (NotificationEvent) argument;
+                final String notification = event.getNotification();
+                final NotificationEvent.NotificationType type = event.getType();
+
+                return notification.equals( ProjectEditorResources.CONSTANTS.BuildSuccessful() ) &&
+                        type.equals( NotificationEvent.NotificationType.SUCCESS );
+            }
+        } ) );
+        verify( notificationEvent ).fire( argThat( new ArgumentMatcher<NotificationEvent>() {
+            @Override
+            public boolean matches( final Object argument ) {
+                final NotificationEvent event = (NotificationEvent) argument;
+                final String notification = event.getNotification();
+                final NotificationEvent.NotificationType type = event.getType();
+
+                return notification.equals( ProjectEditorResources.CONSTANTS.DeploySuccessful() ) &&
+                        type.equals( NotificationEvent.NotificationType.SUCCESS );
+            }
+        } ) );
+        verify( notificationEvent, times( 2 ) ).fire( any( NotificationEvent.class ) );
+        verifyBusyShowHideAnyString( 2, 2 );
+    }
+
+    @Test
+    public void testBuildAndDeployCommandSingleServerTemplateContainerExists() {
+        final String containerName = project.getPom().getGav().getArtifactId();
+        final ServerTemplate serverTemplate = new ServerTemplate("id", "name");
+        serverTemplate.addContainerSpec(new ContainerSpec(containerName, containerName, null, null, null, null));
+        when(specManagementServiceMock.listServerTemplates()).thenReturn(Collections.singletonList(serverTemplate));
+
+        presenter.triggerBuildAndDeploy();
+
+        verify(deploymentScreenPopupView).setValidateExistingContainerCallback(any(DeploymentScreenPopupViewImpl.ValidateExistingContainerCallback.class));
+        verify(deploymentScreenPopupView).setContainerId(containerName);
+        verify(deploymentScreenPopupView).setStartContainer(true);
+        verify(deploymentScreenPopupView).configure(any(com.google.gwt.user.client.Command.class));
+        verify(deploymentScreenPopupView).show();
+        verifyNoMoreInteractions(deploymentScreenPopupView);
+    }
+
+    @Test
+    public void testBuildAndDeployCommandMultipleServerTemplate() {
+        final String containerName = project.getPom().getGav().getArtifactId();
+        final ServerTemplate serverTemplate1 = new ServerTemplate("id1", "name1");
+        final ServerTemplate serverTemplate2 = new ServerTemplate("id2", "name2");
+
+        when(specManagementServiceMock.listServerTemplates()).thenReturn(Arrays.asList(serverTemplate1, serverTemplate2));
+
+        presenter.triggerBuildAndDeploy();
+
+        verify(deploymentScreenPopupView).setValidateExistingContainerCallback(any(DeploymentScreenPopupViewImpl.ValidateExistingContainerCallback.class));
+        verify(deploymentScreenPopupView).setContainerId(containerName);
+        verify(deploymentScreenPopupView).setStartContainer(true);
+        verify(deploymentScreenPopupView).addServerTemplates(eq(Sets.newHashSet("id1", "id2")));
+        verify(deploymentScreenPopupView).configure(any(com.google.gwt.user.client.Command.class));
+        verify(deploymentScreenPopupView).show();
+        verifyNoMoreInteractions(deploymentScreenPopupView);
+    }
+
+    @Test
     public void testBuildAndDeployCommand() {
         presenter.triggerBuildAndDeploy();
 
@@ -300,73 +379,6 @@ public class ProjectScreenPresenterTest {
     }
 
     @Test
-    public void testBuildAndDeployAndProvisionCommand() {
-        presenter.triggerBuildAndDeployAndProvision("my container", "my server");
-
-        verify( notificationEvent, times( 2 ) ).fire( any( NotificationEvent.class ) );
-
-        verify( notificationEvent ).fire( argThat( new ArgumentMatcher<NotificationEvent>() {
-            @Override
-            public boolean matches( final Object argument ) {
-                final NotificationEvent event = (NotificationEvent) argument;
-                final String notification = event.getNotification();
-                final NotificationEvent.NotificationType type = event.getType();
-
-                return notification.equals( ProjectEditorResources.CONSTANTS.BuildSuccessful() ) &&
-                        type.equals( NotificationEvent.NotificationType.SUCCESS );
-            }
-        } ) );
-
-        verify( notificationEvent ).fire( argThat( new ArgumentMatcher<NotificationEvent>() {
-            @Override
-            public boolean matches( final Object argument ) {
-                final NotificationEvent event = (NotificationEvent) argument;
-                final String notification = event.getNotification();
-                final NotificationEvent.NotificationType type = event.getType();
-
-                return notification.equals( ProjectEditorResources.CONSTANTS.DeploySuccessful() ) &&
-                        type.equals( NotificationEvent.NotificationType.SUCCESS );
-            }
-        } ) );
-
-        verifyBusyShowHideAnyString( 2, 2 );
-    }
-
-    @Test
-    public void testBuildAndDeployAndProvisionCommandFail() {
-//        cd jb                                                                                 );
-        BuildMessage message = mock( BuildMessage.class );
-        List<BuildMessage> messages = new ArrayList<BuildMessage>();
-        messages.add( message );
-
-        BuildResults results = mock( BuildResults.class );
-        when( results.getErrorMessages() ).thenReturn( messages );
-
-        when( buildService.buildAndDeploy( any( KieProject.class ),
-                any( DeploymentMode.class ) ) ).thenReturn( results );
-
-        presenter.triggerBuildAndDeployAndProvision("my container", "my server");
-
-        verify( notificationEvent ).fire( argThat(new ArgumentMatcher<NotificationEvent>() {
-            @Override
-            public boolean matches(final Object argument) {
-                final NotificationEvent event = (NotificationEvent) argument;
-                final String notification = event.getNotification();
-                final NotificationEvent.NotificationType type = event.getType();
-
-                return notification.equals(ProjectEditorResources.CONSTANTS.BuildFailed()) &&
-                        type.equals(NotificationEvent.NotificationType.ERROR);
-            }
-        }) );
-
-        verify( view,
-                times( 1 ) ).showBusyIndicator(eq(ProjectEditorResources.CONSTANTS.Building()));
-        //There are two calls to "hide" by this stage; one from the view initialisation one for the build
-        verify( view,
-                times( 2 ) ).hideBusyIndicator();
-    }
-
-    @Test
     public void testAlreadyRunningBuild() {
         constructProjectScreenPresenter( buildServiceCaller(), new CallerMock<SpecManagementService>( specManagementServiceMock ) );
 
@@ -385,20 +397,6 @@ public class ProjectScreenPresenterTest {
 
         presenter.triggerBuildAndDeploy();
         presenter.triggerBuildAndDeploy();
-
-        verify( view, times( 1 ) ).showABuildIsAlreadyRunning();
-        verify( notificationEvent, never() ).fire( any( NotificationEvent.class ) );
-        verifyBusyShowHideAnyString( 3, 2 );
-    }
-
-    @Test
-    public void testAlreadyRunningBuildAndDeployAndProvision() {
-        constructProjectScreenPresenter( buildServiceCaller(), new CallerMock<SpecManagementService>(specManagementServiceMock) );
-
-        presenter.onStartup( mock( PlaceRequest.class ) );
-
-        presenter.triggerBuildAndDeployAndProvision( "my container", "my server" );
-        presenter.triggerBuildAndDeployAndProvision("my container", "my server");
 
         verify( view, times( 1 ) ).showABuildIsAlreadyRunning();
         verify( notificationEvent, never() ).fire( any( NotificationEvent.class ) );
@@ -428,7 +426,7 @@ public class ProjectScreenPresenterTest {
     @Test
     public void testIsDirtyBuildAndDeploy() {
         model.setPOM( mock( POM.class ) ); // causes isDirty evaluates as true
-        presenter.triggerBuildAndDeployAndProvision( "my container", "my server" );
+        presenter.triggerBuildAndDeploy();
 
         verify( view, times( 1 ) ).showSaveBeforeContinue(any(Command.class), any(Command.class), any(Command.class));
         verify( notificationEvent, never() ).fire( any( NotificationEvent.class ) );
@@ -666,7 +664,8 @@ public class ProjectScreenPresenterTest {
                                                 lockManagerInstanceProvider,
                                                 mock( EventSourceMock.class ),
                                                 conflictingRepositoriesPopup,
-                                                specManagementServiceCaller) {
+                                                specManagementServiceCaller,
+                                                deploymentScreenPopupView) {
 
             @Override
             protected void setupPathToPomXML() {


### PR DESCRIPTION
Update logic to the following:
If no server template is availbe, only build and deploy.
If there is only one server template, that is used by default. Select isn't shown.
Default container name is composed by GAV package plus artifact names.
If default container name is already in use, show popup for user to inpur different name.
Start container by default.
Added container name validation.
If there is more than one server template, pop up is shown to enable selection.
